### PR TITLE
Scala Native化 + Lambda zipデプロイ + CIのOIDC化

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+bootstrap
+node_modules
+package-lock.json
+.serverless
+.scala-build
+.bsp
+.metals
+.bloop
+target
+.idea
+.vscode
+env.yml

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -2,6 +2,10 @@ name: serverless-dev
 
 on: pull_request
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: deploy
@@ -22,8 +26,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: get env

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -16,6 +16,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: install plugins
+        run: npm install
+
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ project/plugins/project/
 
 bootstrap
 
+node_modules/
+package-lock.json
+
 .idea/
 
 .vscode/launch.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS
+
+## review
+
+Always review in Japanese.
+
+## github
+
+- 機能実装時はデフォルトブランチへのPRを作成する
+- ある程度の単位でcommit、pushしPRとissueが存在すれば更新する
+- PRに付いた指摘が無いか都度確認してあれば必要な対応か検討して、必要なら修正する
+  - 付いた指摘に対してはcommit idをつけて返答をしてresolveする
+- PRのスコープ外の問題が発覚した場合は別途issueを作成する
+- issueの解決を目的とした場合は修正中都度issueの本文を更新し必要に応じてコメントをつける

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
+# Build-only image: compiles the Scala Native `bootstrap` binary.
+# The artifact is extracted from this image and deployed as a Lambda zip
+# (provided.al2 custom runtime) instead of being shipped as a container image.
 FROM virtuslab/scala-cli:latest as build-image
+
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
 COPY ./ ./
 
 RUN scala-cli clean .
 RUN scala-cli config power true
-RUN scala-cli --power package --native-image -o bootstrap .
+# target GraalVM
+# RUN scala-cli --power package --native-image -o bootstrap .
+# target Scala Native
+RUN scala-cli --power package --native -o bootstrap .
 RUN chmod +x bootstrap
-
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/bootstrap /var/runtime/
-
-CMD ["dummyHandler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,29 @@
-# Build-only image: compiles the Scala Native `bootstrap` binary.
+# Build-only image: compiles the Scala Native `bootstrap` binary on Amazon Linux 2023
+# so that glibc and libcurl match the Lambda `provided.al2023` runtime exactly
+# (a binary built on Debian links against an incompatible libcurl/glibc and crashes
+# on Lambda with GLIBC_* not found / curl OPERATION_TIMEDOUT).
+#
 # The artifact is extracted from this image and deployed as a Lambda zip
-# (provided.al2 custom runtime) instead of being shipped as a container image.
-FROM virtuslab/scala-cli:latest as build-image
+# (provided.al2023 custom runtime) instead of being shipped as a container image.
+FROM --platform=linux/amd64 amazonlinux:2023 AS build-image
 
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y \
+      clang \
+      gcc \
+      glibc-devel \
+      libstdc++-devel \
+      zlib-devel \
+      libcurl-devel \
+      openssl-devel \
+      libidn2-devel \
+      java-17-amazon-corretto-headless \
+      tar gzip which findutils \
+    && dnf clean all
+
+# scala-cli (static x86_64 linux launcher)
+RUN curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.gz \
+      | gunzip > /usr/local/bin/scala-cli \
+    && chmod +x /usr/local/bin/scala-cli
 
 WORKDIR /work
 COPY ./ ./

--- a/README.md
+++ b/README.md
@@ -2,10 +2,30 @@
 
   - githubの未レビューPRを集計しslackで通知
   - scala3
-    - GraalVM
+    - Scala Native
     - scala-cli
   - aws lambda
+    - provided.al2 カスタムランタイム (zipアップロード形式)
   - serverless framework
+
+## デプロイ
+
+`bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
+ビルドは Lambda 実行環境と互換性を保つためコンテナ内で行う。
+
+`serverless-plugin-scripts` により、`sls deploy` / `sls package` の
+パッケージング直前 (`before:package:createDeploymentArtifacts`) に
+`bootstrap` が自動でビルド・取り出しされる (Docker が必要)。
+
+```shell
+# プラグインをインストール
+npm install
+
+# デプロイ (bootstrap の生成 → zip化 → アップロードまで自動)
+sls deploy --stage <stage_name>
+```
+
+## 環境変数 (env.yml)
 
 ```
 WEBHOOK_URL: <通知用webhook>

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
     - Scala Native
     - scala-cli
   - aws lambda
-    - provided.al2 カスタムランタイム (zipアップロード形式)
+    - provided.al2023 カスタムランタイム (zipアップロード形式)
   - serverless framework
 
 ## デプロイ
 
 `bootstrap` (Scala Nativeバイナリ) をビルドして zip でアップロードする。
-ビルドは Lambda 実行環境と互換性を保つためコンテナ内で行う。
+ビルドは Lambda 実行環境 (provided.al2023) と glibc/libcurl の互換性を保つため、
+Amazon Linux 2023 のコンテナ内で行う ([Dockerfile](Dockerfile))。
 
 `serverless-plugin-scripts` により、`sls deploy` / `sls package` の
 パッケージング直前 (`before:package:createDeploymentArtifacts`) に

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,3 @@
+# review
+
+Always review in Japanese.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-review-notifications-slack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "githubの未レビューPRを集計しslackで通知",
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/project.scala
+++ b/project.scala
@@ -1,5 +1,7 @@
-//> using packaging.graalvmArgs --static
-//> using packaging.graalvmArgs --no-fallback
+// for GraalVM
+// //> using packaging.graalvmArgs --static
+// //> using packaging.graalvmArgs --no-fallback
+// for Scala Native
+//> using platform native
 //> using toolkit default
-//> using dep "com.softwaremill.sttp.client4::core:4.0.0-M20"
-//> using dep "com.lihaoyi::upickle:4.0.2"
+//> using dep "com.lihaoyi::upickle:4.4.2"

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,7 @@ custom:
 
 provider:
   name: aws
-  runtime: provided.al2
+  runtime: provided.al2023
   architecture: x86_64
   timeout: 300
   region: ap-northeast-1

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,27 +1,38 @@
 service: no-review-notifications-slack
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
   defaultStage: dev
+  scripts:
+    hooks:
+      # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
+      # Docker内でビルドして取り出す。
+      "before:package:createDeploymentArtifacts": |
+        docker build --platform linux/amd64 -t no-review-notifications-slack-build .
+        id=$(docker create --platform linux/amd64 no-review-notifications-slack-build)
+        docker cp "$id":/work/bootstrap ./bootstrap
+        docker rm "$id"
+        chmod +x bootstrap
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
+  architecture: x86_64
   timeout: 300
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   environment:
     ${file(./env.yml)}
 
+package:
+  patterns:
+    - "!**"
+    - bootstrap
+
 functions:
   no_review_notifications_slack:
-    image:
-      name: appImage
-      command:
-        - handler
+    handler: handler
     events:
       - schedule: cron(0 8 * * ? *) # UTC


### PR DESCRIPTION
## 概要

GraalVM native-image + Docker(ECRイメージ) 構成から、Scala Native + zip アップロード構成へ移行し、CI の AWS 認証を OIDC 化する。

## 変更内容

### Scala Native 化
- `project.scala`: GraalVM native-image → `//> using platform native`（Scala Native）。upickle を 4.4.2 に更新
- アプリのソースは変更なし（Native 互換を確認）

### Lambda を Docker から zip 形式へ
- `serverless.yml`: ECR/イメージ指定を削除し、`provided.al2023` カスタムランタイム + zip パッケージ（`bootstrap` のみ同梱）に変更
- `serverless-plugin-scripts` を導入し、`before:package:createDeploymentArtifacts` フックで `bootstrap` を自動ビルド・取り出し（`package.json` 追加）
- `Dockerfile`: ビルド専用イメージに転用。実行環境(provided.al2023)と glibc/libcurl を一致させるため **Amazon Linux 2023** ベースでビルド（Debian ビルドだと `GLIBC_* not found` / curl `OPERATION_TIMEDOUT` でクラッシュするため）
- `.dockerignore` 追加（古い `bootstrap` や `.git`/`node_modules` の混入を防止）

### CI の OIDC 化
- `.github/workflows/serverless-dev.yml`: アクセスキー認証 → GitHub OIDC で IAM ロール (`AWS_ROLE_ARN`) を引き受け。`permissions: id-token: write` を追加
- AWS 側に専用デプロイロール `no-review-notifications-slack-gha-deploy`（最小権限、当リポジトリのみ信頼）を作成済み

## 動作確認

- `sls deploy --stage dev`（Docker版 remove → zip版 deploy）成功
- `sls invoke`（`{"time": ...}` ペイロード）で `{"statusCode":200,"body":"ok"}` を確認。CloudWatch ログもエラー・警告なしで完走

## 補足（要対応）

- 移行後は不要になる認証情報は手動削除を推奨: GitHub Secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`、IAM ユーザー `slsdeploy` のアクセスキー
- OIDC のトークン交換は本 PR の Actions 実行で初めて検証される

🤖 Generated with [Claude Code](https://claude.com/claude-code)