### PR TITLE
feat: スケジュール実行を prod のみに変更 + prod デプロイワークフロー追加

### DIFF
--- a/.github/workflows/serverless-prod.yml
+++ b/.github/workflows/serverless-prod.yml
@@ -1,0 +1,42 @@
+name: serverless-prod
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: setup node.js
+        uses: actions/setup-node@v4
+
+      - name: install sls
+        run: npm i -g serverless
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install plugins
+        run: npm install
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+
+      - name: get env
+        run: |
+          aws s3 cp s3://limit7412-workflow-env/no_review_notifications_slack/prod/env.yml .
+
+      - name: deploy
+        run: sls deploy --stage prod
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,10 @@ plugins:
 
 custom:
   defaultStage: dev
+  # スケジュール実行は prod ステージでのみ有効にする。
+  # それ以外のステージ(dev等)ではデプロイされるが EventBridge ルールは無効化される。
+  scheduleEnabled:
+    prod: true
   scripts:
     hooks:
       # パッケージング(zip化)直前に、Lambda互換のネイティブバイナリ bootstrap を
@@ -35,4 +39,6 @@ functions:
   no_review_notifications_slack:
     handler: handler
     events:
-      - schedule: cron(0 8 * * ? *) # UTC
+      - schedule:
+          rate: cron(0 8 * * ? *) # UTC
+          enabled: ${self:custom.scheduleEnabled.${self:provider.stage}, false}

--- a/serverless.yml
+++ b/serverless.yml
@@ -41,4 +41,4 @@ functions:
     events:
       - schedule:
           rate: cron(0 8 * * ? *) # UTC
-          enabled: ${self:custom.scheduleEnabled.${self:provider.stage}, false}
+          enabled: ${self:custom.scheduleEnabled.${sls:stage}, false}


### PR DESCRIPTION
## 概要

develop ブランチを廃止し master 単独運用へ移行する準備。

## 変更内容

- **serverless.yml**: schedule イベントを prod ステージでのみ有効化（dev 等ではルールを作成するが無効）
- **.github/workflows/serverless-prod.yml**: master への push 時に `sls deploy --stage prod` を実行するワークフローを追加

## 確認・注意点

- prod 用 `env.yml`（`ENV: prod` 等）が S3 の `prod/` パスに用意されているか要確認
- この PR の作成により `serverless-dev` ワークフローが走り dev 環境へ反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)