### PR TITLE
refactor: フェーズ1 Scala らしい記法へ

### DIFF
--- a/src/github/Repository.scala
+++ b/src/github/Repository.scala
@@ -15,7 +15,7 @@ private def githubRequest(method: Method, path: Uri) = {
 
 object RepoRepository {
   def findByUsername(username: String) = {
-    var response =
+    val response =
       githubRequest(Method.GET, uri"${GITHUB_API_URL}/users/${username}/repos")
         .send()
 
@@ -31,7 +31,7 @@ object RepoRepository {
   }
 
   def findByTeam(login: String, slug: String) = {
-    var response =
+    val response =
       githubRequest(
         Method.GET,
         uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/repos"
@@ -54,7 +54,7 @@ object RepoRepository {
 
 object OrganizationRepository {
   def findByUsername(username: String) = {
-    var response =
+    val response =
       githubRequest(Method.GET, uri"${GITHUB_API_URL}/users/${username}/orgs")
         .send()
 
@@ -72,7 +72,7 @@ object OrganizationRepository {
 
 object TeamRepository {
   def findByOrganization(login: String) = {
-    var response =
+    val response =
       githubRequest(Method.GET, uri"${GITHUB_API_URL}/orgs/${login}/teams")
         .send()
 
@@ -90,7 +90,7 @@ object TeamRepository {
 
 object UserRepository {
   def findByTeam(login: String, slug: String) = {
-    var response =
+    val response =
       githubRequest(
         Method.GET,
         uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/members"

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -10,37 +10,28 @@ object Usecase {
 
     val orgTeamsMap = OrganizationRepository
       .findByUsername(userName)
-      .map({ org =>
+      .map { org =>
         val team = TeamRepository
           .findByOrganization(org.login)
-          .filter({ team =>
+          .filter { team =>
             UserRepository
               .findByTeam(org.login, team.slug)
-              .exists({ user => user.login == userName })
-          })
+              .exists(_.login == userName)
+          }
 
         (org, team)
-      })
+      }
       .toMap
 
     val teamRepos =
-      orgTeamsMap
-        .flatMap({ (org, teams) =>
-          teams
-            .flatMap({ team =>
-              RepoRepository.findByTeam(org.login, team.slug)
-            })
-        })
-        .toList
+      orgTeamsMap.flatMap { (org, teams) =>
+        teams.flatMap(team => RepoRepository.findByTeam(org.login, team.slug))
+      }.toList
 
     val teamSlugs = orgTeamsMap
-      .flatMap({ (_, teams) =>
-        teams
-      })
+      .flatMap((_, teams) => teams)
       .toList
-      .map({ team =>
-        team.slug
-      })
+      .map(_.slug)
 
     (userRepos ++ teamRepos, teamSlugs)
   }
@@ -51,30 +42,18 @@ object Usecase {
     val (repos, teamSlugs) = getRepos
 
     val allPulls = repos
-      .flatMap({ repo =>
-        PullRepository
-          .findByFullName(repo.owner.login, repo.name)
-      })
+      .flatMap(repo =>
+        PullRepository.findByFullName(repo.owner.login, repo.name)
+      )
 
     val assignPulls = allPulls
-      .filter({ pull =>
-        pull.assignees
-          .exists({ user => user.login == userName })
-      })
+      .filter(_.assignees.exists(_.login == userName))
 
     val reviewerPulls = allPulls
-      .filter({ pull =>
-        pull.requested_reviewers
-          .exists({ user => user.login == userName })
-      })
+      .filter(_.requested_reviewers.exists(_.login == userName))
 
     val teamReviewerPulls = allPulls
-      .filter({ pull =>
-        pull.requested_teams
-          .exists({ team =>
-            teamSlugs.exists({ teamSlug => teamSlug == team.slug })
-          })
-      })
+      .filter(_.requested_teams.exists(team => teamSlugs.contains(team.slug)))
 
     (assignPulls, reviewerPulls, teamReviewerPulls)
   }

--- a/src/holiday/Repository.scala
+++ b/src/holiday/Repository.scala
@@ -8,7 +8,7 @@ import sttp.model.Uri
 // https://s-proj.com/utils/holiday.html
 object CheckHolidayRepository {
   def get = {
-    var response =
+    val response =
       basicRequest
         .method(Method.GET, uri"https://s-proj.com/utils/checkHoliday.php")
         .send()

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -10,7 +10,7 @@ object Usecase {
     val (assignPulls, reviewerPulls, teamReviewerPulls) =
       github.Usecase.getAssignPulls
 
-    val isReviewer = ((reviewerPulls ++ teamReviewerPulls).sizeIs >= 1)
+    val isReviewer = (reviewerPulls ++ teamReviewerPulls).nonEmpty
 
     val mention = if (isReviewer && !isHoliday) {
       s"<@${sys.env("SLACK_ID")}> "
@@ -31,22 +31,18 @@ object Usecase {
       ),
       slack.Models.Attachment(
         title = "reviewer",
-        color = if (reviewerPulls.sizeIs >= 1) "#dc143c" else "#D8D8D8",
-        text =
-          reviewerPulls.map({ pull => { pull.toSlackLink() } }).mkString("\n")
+        color = if (reviewerPulls.nonEmpty) "#dc143c" else "#D8D8D8",
+        text = reviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "reviewer(team)",
-        color = if (teamReviewerPulls.sizeIs >= 1) "#ff8c00" else "#D8D8D8",
-        text = teamReviewerPulls
-          .map({ pull => { pull.toSlackLink() } })
-          .mkString("\n")
+        color = if (teamReviewerPulls.nonEmpty) "#ff8c00" else "#D8D8D8",
+        text = teamReviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "assign",
-        color = if (assignPulls.sizeIs >= 1) "#1e90ff" else "#D8D8D8",
-        text =
-          assignPulls.map({ pull => { pull.toSlackLink() } }).mkString("\n")
+        color = if (assignPulls.nonEmpty) "#1e90ff" else "#D8D8D8",
+        text = assignPulls.map(_.toSlackLink()).mkString("\n")
       )
     )
 

--- a/src/runtime/Lambda.scala
+++ b/src/runtime/Lambda.scala
@@ -21,7 +21,7 @@ object Lambda {
     this
   }
   private def handler[A: Reader](callback: A => Response): Lambda.type = {
-    var response = quickRequest
+    val response = quickRequest
       .get(
         uri"http://${sys.env("AWS_LAMBDA_RUNTIME_API")}/2018-06-01/runtime/invocation/next"
       )


### PR DESCRIPTION
## 概要

#15 のフェーズ1。**挙動を変えない**機械的・低リスクな Scala 記法の改善。

## 変更内容

- **`var` → `val`**: 再代入されていない `response`（`Lambda.scala` / `github/Repository.scala` ×5 / `holiday/Repository.scala`）
- **冗長なラムダ式の簡潔化**: 二重波括弧 `.map({ x => { ... } })` を排除し、`_` 省略記法へ（`.exists(_.login == userName)` など）。`teamSlugs.exists(_ == team.slug)` は `teamSlugs.contains(...)` に
- **`sizeIs >= 1` → `.nonEmpty`**: `notify/Usecase.scala`

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み
- ロジックの変更なし

refs #15
