### PR TITLE
refactor: フェーズ2 null デフォルトを Option へ

### DIFF
--- a/src/github/Models.scala
+++ b/src/github/Models.scala
@@ -6,7 +6,7 @@ object Models {
   case class Repo(
       name: String = "",
       full_name: String = "",
-      owner: User = null,
+      owner: Option[User] = None,
       pulls_url: String = ""
   ) derives ReadWriter
 
@@ -34,18 +34,20 @@ object Models {
       html_url: String = "",
       title: String = "",
       state: String = "",
-      user: User = null,
+      user: Option[User] = None,
       assignees: List[User] = Nil,
       requested_reviewers: List[User] = Nil,
       requested_teams: List[Team] = Nil,
-      base: PullBase = null
+      base: Option[PullBase] = None
   ) derives ReadWriter {
     def toSlackLink() = {
-      s"[${base.repo.full_name}] <${html_url}|${title}> (from ${user.toSlackLink()})"
+      val repoName = base.flatMap(_.repo).map(_.full_name).getOrElse("")
+      val from = user.map(_.toSlackLink()).getOrElse("")
+      s"[${repoName}] <${html_url}|${title}> (from ${from})"
     }
   }
 
   case class PullBase(
-      repo: Repo = null
+      repo: Option[Repo] = None
   ) derives ReadWriter
 }

--- a/src/github/Models.scala
+++ b/src/github/Models.scala
@@ -42,8 +42,9 @@ object Models {
   ) derives ReadWriter {
     def toSlackLink() = {
       val repoName = base.flatMap(_.repo).map(_.full_name).getOrElse("")
-      val from = user.map(_.toSlackLink()).getOrElse("")
-      s"[${repoName}] <${html_url}|${title}> (from ${from})"
+      val fromSuffix =
+        user.map(u => s" (from ${u.toSlackLink()})").getOrElse("")
+      s"[${repoName}] <${html_url}|${title}>$fromSuffix"
     }
   }
 

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -28,10 +28,7 @@ object Usecase {
         teams.flatMap(team => RepoRepository.findByTeam(org.login, team.slug))
       }.toList
 
-    val teamSlugs = orgTeamsMap
-      .flatMap((_, teams) => teams)
-      .toList
-      .map(_.slug)
+    val teamSlugs = orgTeamsMap.values.flatten.map(_.slug).toList
 
     (userRepos ++ teamRepos, teamSlugs)
   }
@@ -41,12 +38,11 @@ object Usecase {
 
     val (repos, teamSlugs) = getRepos
 
-    val allPulls = repos
-      .flatMap(repo =>
-        repo.owner.toList.flatMap(owner =>
-          PullRepository.findByFullName(owner.login, repo.name)
-        )
-      )
+    val allPulls = for {
+      repo <- repos
+      owner <- repo.owner.toList
+      pull <- PullRepository.findByFullName(owner.login, repo.name)
+    } yield pull
 
     val assignPulls = allPulls
       .filter(_.assignees.exists(_.login == userName))

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -43,7 +43,9 @@ object Usecase {
 
     val allPulls = repos
       .flatMap(repo =>
-        PullRepository.findByFullName(repo.owner.login, repo.name)
+        repo.owner.toList.flatMap(owner =>
+          PullRepository.findByFullName(owner.login, repo.name)
+        )
       )
 
     val assignPulls = allPulls

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -10,7 +10,7 @@ object Usecase {
     val (assignPulls, reviewerPulls, teamReviewerPulls) =
       github.Usecase.getAssignPulls
 
-    val isReviewer = (reviewerPulls ++ teamReviewerPulls).nonEmpty
+    val isReviewer = reviewerPulls.nonEmpty || teamReviewerPulls.nonEmpty
 
     val mention = if (isReviewer && !isHoliday) {
       s"<@${sys.env("SLACK_ID")}> "


### PR DESCRIPTION
## 概要

#15 のフェーズ2。`github/Models.scala` の `null` デフォルト値を `Option[T]` 化し、ランタイムの NPE を防止する。

## 背景

`Pull.toSlackLink` は `base.repo.full_name` を参照しており、GitHub API レスポンスの JSON に `base` が欠けていると `NullPointerException` でクラッシュする。upickle は `Option` を欠損許容でデコードできるため、`Option` 化することで堅牢になる。

## 変更内容

- `Repo.owner` / `Pull.user` / `Pull.base` / `PullBase.repo` を `Option[T] = None` に変更
- `Pull.toSlackLink` を `Option` 考慮の実装に（欠損時は空文字でフォールバック）
- `github/Usecase.scala` の `repo.owner.login` 参照を `Option` 対応に（owner が None のリポジトリはスキップ）

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み

refs #15
