### PR TITLE
docs: 意図が読み取りにくい箇所に説明コメントを追記

### DIFF
--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -6,8 +6,12 @@ object Usecase {
   def getRepos = {
     val userName = sys.env("GITHUB_USERNAME")
 
+    // 本人が所有するリポジトリ
     val userRepos = RepoRepository.findByUsername(userName)
 
+    // 本人が所属する各 org について、「その org 内で本人がメンバーになっているチーム」だけを抽出し
+    // org -> 所属チーム一覧 の対応を作る。
+    // (org にチームが多数あっても、本人が無関係なチームは以降の集計対象から除外される)
     val orgTeamsMap = OrganizationRepository
       .findByUsername(userName)
       .map { org =>
@@ -23,11 +27,13 @@ object Usecase {
       }
       .toMap
 
+    // 本人が所属するチームがアクセスできるリポジトリ
     val teamRepos =
       orgTeamsMap.flatMap { (org, teams) =>
         teams.flatMap(team => RepoRepository.findByTeam(org.login, team.slug))
       }.toList
 
+    // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う。
     val teamSlugs = orgTeamsMap.values.flatten.map(_.slug).toList
 
     (userRepos ++ teamRepos, teamSlugs)
@@ -38,18 +44,24 @@ object Usecase {
 
     val (repos, teamSlugs) = getRepos
 
+    // 対象リポジトリすべての open PR を集約する。
+    // repo.owner は Option のため .toList で List に変換し、owner 不明のリポジトリはスキップする
+    // (Option と List を for 内包表記で混在させるとモナドが揃わずコンパイルできないため)。
     val allPulls = for {
       repo <- repos
       owner <- repo.owner.toList
       pull <- PullRepository.findByFullName(owner.login, repo.name)
     } yield pull
 
+    // 本人が assignee に指定されている PR
     val assignPulls = allPulls
       .filter(_.assignees.exists(_.login == userName))
 
+    // 本人が個人としてレビュアー指名されている PR
     val reviewerPulls = allPulls
       .filter(_.requested_reviewers.exists(_.login == userName))
 
+    // 本人の所属チームがレビュアー指名されている PR
     val teamReviewerPulls = allPulls
       .filter(_.requested_teams.exists(team => teamSlugs.contains(team.slug)))
 

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -6,12 +6,11 @@ object Usecase {
   def getRepos = {
     val userName = sys.env("GITHUB_USERNAME")
 
-    // 本人が所有するリポジトリ
     val userRepos = RepoRepository.findByUsername(userName)
 
-    // 本人が所属する各 org について、「その org 内で本人がメンバーになっているチーム」だけを抽出し
-    // org -> 所属チーム一覧 の対応を作る。
-    // (org にチームが多数あっても、本人が無関係なチームは以降の集計対象から除外される)
+    // 本人が所属する各 org について
+    // 「その org 内で本人がメンバーになっているチーム」だけを抽出し
+    // org -> 所属チーム一覧 の対応を作る
     val orgTeamsMap = OrganizationRepository
       .findByUsername(userName)
       .map { org =>
@@ -33,7 +32,7 @@ object Usecase {
         teams.flatMap(team => RepoRepository.findByTeam(org.login, team.slug))
       }.toList
 
-    // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う。
+    // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
     val teamSlugs = orgTeamsMap.values.flatten.map(_.slug).toList
 
     (userRepos ++ teamRepos, teamSlugs)
@@ -44,9 +43,10 @@ object Usecase {
 
     val (repos, teamSlugs) = getRepos
 
-    // 対象リポジトリすべての open PR を集約する。
-    // repo.owner は Option のため .toList で List に変換し、owner 不明のリポジトリはスキップする
-    // (Option と List を for 内包表記で混在させるとモナドが揃わずコンパイルできないため)。
+    // 対象リポジトリすべての open PR を集約する
+    // repo.owner は Option のため .toList で List に変換し
+    // owner 不明のリポジトリはスキップする
+    // (Option と List を for 内包表記で混在させるとモナドが揃わずコンパイルできないため)
     val allPulls = for {
       repo <- repos
       owner <- repo.owner.toList

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -10,20 +10,15 @@ object Usecase {
     val (assignPulls, reviewerPulls, teamReviewerPulls) =
       github.Usecase.getAssignPulls
 
-    // 自分(個人) または 所属チーム宛のレビュー依頼が1件でも残っているか。
-    // これが true のときだけ「至急対応すべきレビューがある」状態とみなす。
-    // (単にレビュアー以外でアサインされているだけの状態とは区別する)
+    // 片方でもレビュアー指名されているPRが存在すれば通知対象
     val isReviewer = reviewerPulls.nonEmpty || teamReviewerPulls.nonEmpty
 
-    // 至急対応すべきレビューがあり、かつ平日のときだけ本人にメンションする。
-    // 休日は通知だけ行いメンション(呼び出し)はしない。
     val mention = if (isReviewer && !isHoliday) {
       s"<@${sys.env("SLACK_ID")}> "
     } else {
       ""
     }
 
-    // レビュー依頼の有無でメッセージの文面(催促 or 単なるお知らせ)を切り替える。
     val message = if (isReviewer) {
       "レビュー依頼が残っているみたいです！至急確認しましょう！"
     } else {

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -10,14 +10,20 @@ object Usecase {
     val (assignPulls, reviewerPulls, teamReviewerPulls) =
       github.Usecase.getAssignPulls
 
+    // 自分(個人) または 所属チーム宛のレビュー依頼が1件でも残っているか。
+    // これが true のときだけ「至急対応すべきレビューがある」状態とみなす。
+    // (単にレビュアー以外でアサインされているだけの状態とは区別する)
     val isReviewer = reviewerPulls.nonEmpty || teamReviewerPulls.nonEmpty
 
+    // 至急対応すべきレビューがあり、かつ平日のときだけ本人にメンションする。
+    // 休日は通知だけ行いメンション(呼び出し)はしない。
     val mention = if (isReviewer && !isHoliday) {
       s"<@${sys.env("SLACK_ID")}> "
     } else {
       ""
     }
 
+    // レビュー依頼の有無でメッセージの文面(催促 or 単なるお知らせ)を切り替える。
     val message = if (isReviewer) {
       "レビュー依頼が残っているみたいです！至急確認しましょう！"
     } else {


### PR DESCRIPTION
## 概要

`isReviewer` をはじめ、意図が読み取りにくい箇所に説明コメントを追記する。**ロジックの変更はなし**（コメント追記のみ）。

## 変更内容

### `src/notify/Usecase.scala`
- **`isReviewer`**: 「個人 または 所属チーム宛のレビュー依頼が残っているか」を表し、これが `true` のときだけ「至急対応すべき」状態とみなす意図を明記（単なるアサイン状態との区別）
- **`mention`**: 「レビュー依頼あり かつ 平日」のときのみ本人にメンションし、休日は通知のみ行う意図を明記
- **`message`**: 催促文 / お知らせ文を切り替えている旨を明記

### `src/github/Usecase.scala`
- `org -> 本人が所属するチーム一覧` を抽出するロジックの意図
- `teamRepos` / `teamSlugs` の用途
- `allPulls` の for 内包表記で `repo.owner.toList` としている理由（`Option` と `List` を混在させるとモナドが揃わずコンパイルできないため）
- `assignPulls` / `reviewerPulls` / `teamReviewerPulls` 3種フィルタの違い

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 整形に変化なし

refs #15
