### PR TITLE
refactor: フェーズ3 重複コードの集約 (DRY)

### DIFF
--- a/src/config/Config.scala
+++ b/src/config/Config.scala
@@ -13,7 +13,8 @@ case class Config(
 
 object Config {
   // 起動時に1度だけ読み込む。必須環境変数が欠落していれば例外で即座に失敗する。
-  lazy val instance: Config = load()
+  // lazy val ではなく val とし、Cold Start の初期化フェーズで欠落を早期検知する。
+  val instance: Config = load()
 
   private def load(): Config =
     Config(

--- a/src/config/Config.scala
+++ b/src/config/Config.scala
@@ -1,0 +1,34 @@
+package config
+
+// アプリ全体で参照する環境変数を1箇所に集約する。
+// 各所に散在していた sys.env(...) の文字列キー直書きを排除し、
+// 型付きのフィールドアクセスに統一する。
+case class Config(
+    githubToken: String,
+    githubUsername: String,
+    slackId: String,
+    webhookUrl: String,
+    env: String
+)
+
+object Config {
+  // 起動時に1度だけ読み込む。必須環境変数が欠落していれば例外で即座に失敗する。
+  lazy val instance: Config = load()
+
+  private def load(): Config =
+    Config(
+      githubToken = require("GITHUB_TOKEN"),
+      githubUsername = require("GITHUB_USERNAME"),
+      slackId = require("SLACK_ID"),
+      webhookUrl = require("WEBHOOK_URL"),
+      env = require("ENV")
+    )
+
+  private def require(key: String): String =
+    sys.env.getOrElse(
+      key,
+      throw new RuntimeException(
+        s"required environment variable not set: ${key}"
+      )
+    )
+}

--- a/src/github/Repository.scala
+++ b/src/github/Repository.scala
@@ -10,126 +10,61 @@ val GITHUB_API_URL = "https://api.github.com"
 private def githubRequest(method: Method, path: Uri) = {
   basicRequest
     .method(method, path)
-    .header("Authorization", s"token ${sys.env("GITHUB_TOKEN")}")
+    .header("Authorization", s"token ${config.Config.instance.githubToken}")
 }
 
+// GitHub API から List[T] を取得する共通処理。
+// 取得失敗時は label を添えて警告ログを出し、空リストを返して処理を継続する。
+private def getList[T: Reader](path: Uri, label: => String): List[T] =
+  githubRequest(Method.GET, path).send().body match {
+    case Right(res) => read[List[T]](res)
+    case Left(e) =>
+      System.err.println(s"${label} not found: ${e}")
+      Nil
+  }
+
 object RepoRepository {
-  def findByUsername(username: String) = {
-    val response =
-      githubRequest(Method.GET, uri"${GITHUB_API_URL}/users/${username}/repos")
-        .send()
+  def findByUsername(username: String) =
+    getList[Models.Repo](
+      uri"${GITHUB_API_URL}/users/${username}/repos",
+      s"user(${username}) repos data"
+    )
 
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(s"user(${username}) repos data not found: ${e}")
-        "[]"
-      }
-    }
-
-    read[List[Models.Repo]](body)
-  }
-
-  def findByTeam(login: String, slug: String) = {
-    val response =
-      githubRequest(
-        Method.GET,
-        uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/repos"
-      )
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(
-          s"team(${login}, ${slug}) repos data not found: ${e}"
-        )
-        "[]"
-      }
-    }
-
-    read[List[Models.Repo]](body)
-  }
+  def findByTeam(login: String, slug: String) =
+    getList[Models.Repo](
+      uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/repos",
+      s"team(${login}, ${slug}) repos data"
+    )
 }
 
 object OrganizationRepository {
-  def findByUsername(username: String) = {
-    val response =
-      githubRequest(Method.GET, uri"${GITHUB_API_URL}/users/${username}/orgs")
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(s"user(${username}) orgs data not found: ${e}")
-        "[]"
-      }
-    }
-
-    read[List[Models.Organization]](body)
-  }
+  def findByUsername(username: String) =
+    getList[Models.Organization](
+      uri"${GITHUB_API_URL}/users/${username}/orgs",
+      s"user(${username}) orgs data"
+    )
 }
 
 object TeamRepository {
-  def findByOrganization(login: String) = {
-    val response =
-      githubRequest(Method.GET, uri"${GITHUB_API_URL}/orgs/${login}/teams")
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(s"org(${login}) teams data not found: ${e}")
-        "[]"
-      }
-    }
-
-    read[List[Models.Team]](body)
-  }
+  def findByOrganization(login: String) =
+    getList[Models.Team](
+      uri"${GITHUB_API_URL}/orgs/${login}/teams",
+      s"org(${login}) teams data"
+    )
 }
 
 object UserRepository {
-  def findByTeam(login: String, slug: String) = {
-    val response =
-      githubRequest(
-        Method.GET,
-        uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/members"
-      )
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(
-          s"team(${login}, ${slug}) members data not found: ${e}"
-        )
-        "[]"
-      }
-    }
-
-    read[List[Models.User]](body)
-  }
+  def findByTeam(login: String, slug: String) =
+    getList[Models.User](
+      uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/members",
+      s"team(${login}, ${slug}) members data"
+    )
 }
 
 object PullRepository {
-  def findByFullName(owner: String, name: String) = {
-    var response =
-      githubRequest(
-        Method.GET,
-        uri"${GITHUB_API_URL}/repos/${owner}/${name}/pulls"
-      )
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(
-          s"target(${owner}, ${name}) pulls data not found: ${e}"
-        )
-        "[]"
-      }
-    }
-
-    read[List[Models.Pull]](body)
-  }
+  def findByFullName(owner: String, name: String) =
+    getList[Models.Pull](
+      uri"${GITHUB_API_URL}/repos/${owner}/${name}/pulls",
+      s"target(${owner}, ${name}) pulls data"
+    )
 }

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -4,7 +4,7 @@ import upickle.default._
 
 object Usecase {
   def getRepos = {
-    val userName = sys.env("GITHUB_USERNAME")
+    val userName = config.Config.instance.githubUsername
 
     val userRepos = RepoRepository.findByUsername(userName)
 
@@ -39,7 +39,7 @@ object Usecase {
   }
 
   def getAssignPulls = {
-    val userName = sys.env("GITHUB_USERNAME")
+    val userName = config.Config.instance.githubUsername
 
     val (repos, teamSlugs) = getRepos
 

--- a/src/main.scala
+++ b/src/main.scala
@@ -1,7 +1,7 @@
 import serverless.Lambda
 import notify.Usecase
 
-@main def main = sys.env("ENV") match {
+@main def main = config.Config.instance.env match {
   case "local" => handler("1970-01-01T00:00:00Z")
   case _ =>
     serverless.Lambda

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -14,7 +14,7 @@ object Usecase {
     val isReviewer = reviewerPulls.nonEmpty || teamReviewerPulls.nonEmpty
 
     val mention = if (isReviewer && !isHoliday) {
-      s"<@${sys.env("SLACK_ID")}> "
+      s"<@${config.Config.instance.slackId}> "
     } else {
       ""
     }

--- a/src/slack/Repository.scala
+++ b/src/slack/Repository.scala
@@ -7,7 +7,7 @@ object PostRepository {
   private def sendPost(post: Models.Post) = {
     basicRequest
       .post(
-        uri"${sys.env("WEBHOOK_URL")}"
+        uri"${config.Config.instance.webhookUrl}"
       )
       .body(write(post))
       .send()


### PR DESCRIPTION
## 概要

#15 のフェーズ3（重複コードの集約 / DRY）。**挙動は変えない**。

## 変更内容

### 1. GitHub Repository の共通化
`src/github/Repository.scala` の5メソッドが繰り返していた「リクエスト送信 → `body match { Right / Left }` → `read[List[T]]`」という同一定型を、ジェネリック関数に集約:

```scala
private def getList[T: Reader](path: Uri, label: => String): List[T] =
  githubRequest(Method.GET, path).send().body match {
    case Right(res) => read[List[T]](res)
    case Left(e) =>
      System.err.println(s"${label} not found: ${e}")
      Nil
  }
```

各 Repository メソッドは `getList[...](uri, label)` の宣言1つに簡潔化（-111行）。失敗時に空リストを返すフォールバック挙動は従来どおり維持。

### 2. 設定アクセスの集約（`Config`）
各所に散在していた `sys.env(...)` の文字列キー直書きを `config.Config` に集約し、型付きフィールドアクセスに統一。**起動時に必須環境変数を検証し、欠落時は即座に例外で失敗**する。

- 集約対象: `GITHUB_TOKEN` / `GITHUB_USERNAME` / `SLACK_ID` / `WEBHOOK_URL` / `ENV`
- `_HANDLER` / `AWS_LAMBDA_RUNTIME_API` は AWS が注入する実行環境固有の変数のため `runtime` 層に残置

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み
- ロジック・挙動の変更なし

refs #15
