### PR TITLE
refactor: フェーズ4 エラーハンドリングを Either で統一

### DIFF
--- a/src/errors/AppError.scala
+++ b/src/errors/AppError.scala
@@ -1,0 +1,22 @@
+package errors
+
+// アプリ内で発生したエラーを表す共通型。
+// Repository 層で握りつぶさず Either の Left として Usecase 層まで伝播させ、
+// 境界(main / Lambda ランタイム)でまとめて処理する。
+case class AppError(message: String, cause: Option[Throwable] = None) {
+  def toException: RuntimeException =
+    cause.fold(new RuntimeException(message))(c =>
+      new RuntimeException(message, c)
+    )
+}
+
+// List[A] の各要素に Either を返す f を順に適用し Either[E, List[B]] にまとめる。
+// - foldLeft で実装しておりスタックセーフ(大きなリストでもオーバーフローしない)。
+// - acc が Left になると flatMap が f を評価しなくなるため、最初のエラー以降は
+//   f(API 呼び出し等)が実行されず短絡する(無駄なリクエストを発生させない)。
+def traverse[E, A, B](xs: List[A])(f: A => Either[E, B]): Either[E, List[B]] =
+  xs
+    .foldLeft[Either[E, List[B]]](Right(Nil)) { (acc, x) =>
+      acc.flatMap(bs => f(x).map(_ :: bs))
+    }
+    .map(_.reverse)

--- a/src/github/Repository.scala
+++ b/src/github/Repository.scala
@@ -4,6 +4,8 @@ import sttp.client4.quick._
 import upickle.default._
 import sttp.model.Method
 import sttp.model.Uri
+import scala.util.{Try, Success, Failure}
+import errors.AppError
 
 val GITHUB_API_URL = "https://api.github.com"
 
@@ -14,23 +16,33 @@ private def githubRequest(method: Method, path: Uri) = {
 }
 
 // GitHub API から List[T] を取得する共通処理。
-// 取得失敗時は label を添えて警告ログを出し、空リストを返して処理を継続する。
-private def getList[T: Reader](path: Uri, label: => String): List[T] =
+// HTTP エラーもパース失敗も AppError の Left として返し、
+// 呼び出し側(Usecase 層)で集約・判断できるようにする。
+private def getList[T: Reader](
+    path: Uri,
+    label: => String
+): Either[AppError, List[T]] =
   githubRequest(Method.GET, path).send().body match {
-    case Right(res) => read[List[T]](res)
+    case Right(res) =>
+      Try(read[List[T]](res)) match {
+        case Success(list) => Right(list)
+        case Failure(e) => Left(AppError(s"failed to parse ${label}", Some(e)))
+      }
     case Left(e) =>
-      System.err.println(s"${label} not found: ${e}")
-      Nil
+      Left(AppError(s"${label} not found: ${e}"))
   }
 
 object RepoRepository {
-  def findByUsername(username: String) =
+  def findByUsername(username: String): Either[AppError, List[Models.Repo]] =
     getList[Models.Repo](
       uri"${GITHUB_API_URL}/users/${username}/repos",
       s"user(${username}) repos data"
     )
 
-  def findByTeam(login: String, slug: String) =
+  def findByTeam(
+      login: String,
+      slug: String
+  ): Either[AppError, List[Models.Repo]] =
     getList[Models.Repo](
       uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/repos",
       s"team(${login}, ${slug}) repos data"
@@ -38,7 +50,9 @@ object RepoRepository {
 }
 
 object OrganizationRepository {
-  def findByUsername(username: String) =
+  def findByUsername(
+      username: String
+  ): Either[AppError, List[Models.Organization]] =
     getList[Models.Organization](
       uri"${GITHUB_API_URL}/users/${username}/orgs",
       s"user(${username}) orgs data"
@@ -46,7 +60,7 @@ object OrganizationRepository {
 }
 
 object TeamRepository {
-  def findByOrganization(login: String) =
+  def findByOrganization(login: String): Either[AppError, List[Models.Team]] =
     getList[Models.Team](
       uri"${GITHUB_API_URL}/orgs/${login}/teams",
       s"org(${login}) teams data"
@@ -54,7 +68,10 @@ object TeamRepository {
 }
 
 object UserRepository {
-  def findByTeam(login: String, slug: String) =
+  def findByTeam(
+      login: String,
+      slug: String
+  ): Either[AppError, List[Models.User]] =
     getList[Models.User](
       uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/members",
       s"team(${login}, ${slug}) members data"
@@ -62,7 +79,10 @@ object UserRepository {
 }
 
 object PullRepository {
-  def findByFullName(owner: String, name: String) =
+  def findByFullName(
+      owner: String,
+      name: String
+  ): Either[AppError, List[Models.Pull]] =
     getList[Models.Pull](
       uri"${GITHUB_API_URL}/repos/${owner}/${name}/pulls",
       s"target(${owner}, ${name}) pulls data"

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -1,70 +1,81 @@
 package github
 
-import upickle.default._
+import errors.{AppError, traverse}
 
 object Usecase {
-  def getRepos = {
+  def getRepos: Either[AppError, (List[Models.Repo], List[String])] = {
     val userName = config.Config.instance.githubUsername
 
-    val userRepos = RepoRepository.findByUsername(userName)
-
-    // 本人が所属する各 org について
-    // 「その org 内で本人がメンバーになっているチーム」だけを抽出し
-    // org -> 所属チーム一覧 の対応を作る
-    val orgTeamsMap = OrganizationRepository
-      .findByUsername(userName)
-      .map { org =>
-        val team = TeamRepository
-          .findByOrganization(org.login)
-          .filter { team =>
-            UserRepository
-              .findByTeam(org.login, team.slug)
-              .exists(_.login == userName)
+    // 本人が所有するリポジトリ
+    RepoRepository.findByUsername(userName).flatMap { userRepos =>
+      // 本人が所属する org 一覧
+      OrganizationRepository.findByUsername(userName).flatMap { orgs =>
+        // 各 org について、本人がメンバーになっているチームだけを抽出する
+        // (org -> 所属チーム一覧 の対応)
+        traverse(orgs)(memberTeamsOf(_, userName)).flatMap { orgTeams =>
+          // 本人が所属するチームがアクセスできるリポジトリ
+          // (org/team を平坦化してから順に取得し、失敗時は以降を呼ばず短絡する)
+          traverse(
+            orgTeams.flatMap((org, teams) => teams.map(team => (org, team)))
+          ) { case (org, team) =>
+            RepoRepository.findByTeam(org.login, team.slug)
+          }.map { teamReposNested =>
+            val teamRepos = teamReposNested.flatten
+            // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
+            val teamSlugs = orgTeams.flatMap((_, teams) => teams).map(_.slug)
+            (userRepos ++ teamRepos, teamSlugs)
           }
-
-        (org, team)
+        }
       }
-      .toMap
-
-    // 本人が所属するチームがアクセスできるリポジトリ
-    val teamRepos =
-      orgTeamsMap.flatMap { (org, teams) =>
-        teams.flatMap(team => RepoRepository.findByTeam(org.login, team.slug))
-      }.toList
-
-    // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
-    val teamSlugs = orgTeamsMap.values.flatten.map(_.slug).toList
-
-    (userRepos ++ teamRepos, teamSlugs)
+    }
   }
 
-  def getAssignPulls = {
+  // 指定 org のチームのうち、本人がメンバーになっているものだけを返す
+  private def memberTeamsOf(
+      org: Models.Organization,
+      userName: String
+  ): Either[AppError, (Models.Organization, List[Models.Team])] =
+    TeamRepository.findByOrganization(org.login).flatMap { teams =>
+      traverse(teams) { team =>
+        UserRepository
+          .findByTeam(org.login, team.slug)
+          .map(members => (team, members.exists(_.login == userName)))
+      }.map(memberships =>
+        (org, memberships.collect { case (team, true) => team })
+      )
+    }
+
+  def getAssignPulls: Either[
+    AppError,
+    (List[Models.Pull], List[Models.Pull], List[Models.Pull])
+  ] = {
     val userName = config.Config.instance.githubUsername
 
-    val (repos, teamSlugs) = getRepos
+    getRepos.flatMap { case (repos, teamSlugs) =>
+      // 対象リポジトリすべての open PR を集約する
+      // repo.owner は Option のため owner 不明のリポジトリは対象から除外し、
+      // (owner, repo) を順に取得して失敗時は以降を呼ばず短絡する
+      traverse(
+        repos.flatMap(repo => repo.owner.toList.map(owner => (owner, repo)))
+      ) { case (owner, repo) =>
+        PullRepository.findByFullName(owner.login, repo.name)
+      }.map { pullsNested =>
+        val allPulls = pullsNested.flatten
 
-    // 対象リポジトリすべての open PR を集約する
-    // repo.owner は Option のため .toList で List に変換し
-    // owner 不明のリポジトリはスキップする
-    // (Option と List を for 内包表記で混在させるとモナドが揃わずコンパイルできないため)
-    val allPulls = for {
-      repo <- repos
-      owner <- repo.owner.toList
-      pull <- PullRepository.findByFullName(owner.login, repo.name)
-    } yield pull
+        // 本人が assignee に指定されている PR
+        val assignPulls =
+          allPulls.filter(_.assignees.exists(_.login == userName))
+        // 本人が個人としてレビュアー指名されている PR
+        val reviewerPulls =
+          allPulls.filter(_.requested_reviewers.exists(_.login == userName))
+        // 本人の所属チームがレビュアー指名されている PR
+        val teamReviewerPulls =
+          allPulls.filter(
+            _.requested_teams.exists(team => teamSlugs.contains(team.slug))
+          )
 
-    // 本人が assignee に指定されている PR
-    val assignPulls = allPulls
-      .filter(_.assignees.exists(_.login == userName))
-
-    // 本人が個人としてレビュアー指名されている PR
-    val reviewerPulls = allPulls
-      .filter(_.requested_reviewers.exists(_.login == userName))
-
-    // 本人の所属チームがレビュアー指名されている PR
-    val teamReviewerPulls = allPulls
-      .filter(_.requested_teams.exists(team => teamSlugs.contains(team.slug)))
-
-    (assignPulls, reviewerPulls, teamReviewerPulls)
+        (assignPulls, reviewerPulls, teamReviewerPulls)
+      }
+    }
   }
 }

--- a/src/holiday/Repository.scala
+++ b/src/holiday/Repository.scala
@@ -1,33 +1,24 @@
 package holiday
 
 import sttp.client4.quick._
-import upickle.default._
 import sttp.model.Method
 import sttp.model.Uri
+import errors.AppError
 
 // https://s-proj.com/utils/holiday.html
 object CheckHolidayRepository {
-  def get = {
-    val response =
-      basicRequest
-        .method(Method.GET, uri"https://s-proj.com/utils/checkHoliday.php")
-        .send()
-
-    val body = response.body match {
-      case Right(res) => res
-      case Left(e) => {
-        System.err.println(s"failed get checkHoliday api: ${e}")
-        throw new Error(e)
-      }
+  def get: Either[AppError, Boolean] =
+    basicRequest
+      .method(Method.GET, uri"https://s-proj.com/utils/checkHoliday.php")
+      .send()
+      .body match {
+      case Right("holiday") => Right(true)
+      case Right("else")    => Right(false)
+      case Right("error") =>
+        Left(AppError("checkHoliday api returned error"))
+      case Right(other) =>
+        Left(AppError(s"unexpected checkHoliday response: ${other}"))
+      case Left(e) =>
+        Left(AppError(s"failed to get checkHoliday api: ${e}"))
     }
-
-    body match {
-      case "holiday" => true
-      case "else"    => false
-      case "error" => {
-        System.err.println(s"checkHoliday api return error")
-        throw new Error("checkHoliday api return error")
-      }
-    }
-  }
 }

--- a/src/main.scala
+++ b/src/main.scala
@@ -1,17 +1,26 @@
 import serverless.Lambda
 import notify.Usecase
+import errors.AppError
 
 @main def main = config.Config.instance.env match {
-  case "local" => handler("1970-01-01T00:00:00Z")
+  case "local" =>
+    // Left は例外として送出し非0終了させる(ローカル/CI で失敗を検知できるように)
+    handler("1970-01-01T00:00:00Z") match {
+      case Right(_)  => ()
+      case Left(err) => throw err.toException
+    }
   case _ =>
     serverless.Lambda
       .Handler[serverless.Lambda.CloudWatchScheduledEventRequest](
         "handler",
         (event) => {
-          handler(event.time)
-          serverless.Lambda.Response(200, "ok")
+          // Usecase の Left は例外に変換し、Lambda ランタイムのエラー応答に委ねる
+          handler(event.time) match {
+            case Right(_)  => serverless.Lambda.Response(200, "ok")
+            case Left(err) => throw err.toException
+          }
         }
       )
 }
 
-def handler(time: String) = notify.Usecase.check
+def handler(time: String): Either[AppError, Unit] = notify.Usecase.check

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -1,15 +1,30 @@
 package notify
 
-import slack.PostRepository
-import slack.Models
+import errors.AppError
 
 object Usecase {
-  def check = {
-    val isHoliday = holiday.CheckHolidayRepository.get
+  def check: Either[AppError, Unit] =
+    holiday.CheckHolidayRepository.get.flatMap { isHoliday =>
+      github.Usecase.getAssignPulls.flatMap {
+        case (assignPulls, reviewerPulls, teamReviewerPulls) =>
+          slack.PostRepository.sendAttachments(
+            buildAttachments(
+              isHoliday,
+              assignPulls,
+              reviewerPulls,
+              teamReviewerPulls
+            )
+          )
+      }
+    }
 
-    val (assignPulls, reviewerPulls, teamReviewerPulls) =
-      github.Usecase.getAssignPulls
-
+  // 通知メッセージ(Slack Attachment)を組み立てる純粋ロジック
+  private def buildAttachments(
+      isHoliday: Boolean,
+      assignPulls: List[github.Models.Pull],
+      reviewerPulls: List[github.Models.Pull],
+      teamReviewerPulls: List[github.Models.Pull]
+  ): List[slack.Models.Attachment] = {
     // 片方でもレビュアー指名されているPRが存在すれば通知対象
     val isReviewer = reviewerPulls.nonEmpty || teamReviewerPulls.nonEmpty
 
@@ -25,7 +40,7 @@ object Usecase {
       "現在アサインされているレビューをお知らせします！"
     }
 
-    val attachment = List(
+    List(
       slack.Models.Attachment(
         fallback = message,
         pretext = mention + message
@@ -46,7 +61,5 @@ object Usecase {
         text = assignPulls.map(_.toSlackLink()).mkString("\n")
       )
     )
-
-    slack.PostRepository.sendAttachments(attachment)
   }
 }

--- a/src/slack/Repository.scala
+++ b/src/slack/Repository.scala
@@ -2,22 +2,24 @@ package slack
 
 import sttp.client4.quick._
 import upickle.default._
+import errors.AppError
 
 object PostRepository {
-  private def sendPost(post: Models.Post) = {
+  private def sendPost(post: Models.Post): Either[AppError, Unit] =
     basicRequest
-      .post(
-        uri"${config.Config.instance.webhookUrl}"
-      )
+      .post(uri"${config.Config.instance.webhookUrl}")
       .body(write(post))
       .send()
-  }
+      .body match {
+      case Right(_) => Right(())
+      case Left(e)  => Left(AppError(s"failed to send slack message: ${e}"))
+    }
 
-  def sendAttachment(attachment: Models.Attachment) = {
+  def sendAttachment(attachment: Models.Attachment): Either[AppError, Unit] =
     sendPost(Models.Post(List(attachment)))
-  }
 
-  def sendAttachments(attachments: List[Models.Attachment]) = {
+  def sendAttachments(
+      attachments: List[Models.Attachment]
+  ): Either[AppError, Unit] =
     sendPost(Models.Post(attachments))
-  }
 }


### PR DESCRIPTION
## 概要

#15 のフェーズ4。**Either によるエラー伝播**を導入する。方針は **`Either` で Usecase 層に伝播**。

for 内包表記への移行（構文変更）のみ #24 に分離している。本PRは Usecase 層を **`flatMap`/`map`** で記述する（for 内包表記に関連しない変更はすべて本PRに含む）。

## 変更内容

- **`errors/AppError.scala`（新規）**: 共通エラー型 `AppError(message, cause)` と `traverse` ヘルパー
  - `foldLeft` でスタックセーフ
  - `acc` が `Left` になると `f` を評価しないため、最初のエラー以降の API 呼び出しを行わず短絡する
- **`github/Repository.scala`**: `getList` を `Either` 化。`read` のパース失敗も `Try` で捕捉（PR #22 のレビュー指摘対応）
- **`holiday/Repository.scala`**: `throw new Error` を廃止し `Either` 化。想定外レスポンスも `Left` で表現
- **`slack/Repository.scala`**: 送信失敗を `Either` で表現
- **`github/Usecase.scala`**: `traverse` + `flatMap`/`map` で `Either` を集約。org→所属チーム抽出を `memberTeamsOf` に切り出し
- **`notify/Usecase.scala`**: `check` を `Either` 化。Attachment 組み立てを純粋関数 `buildAttachments` に分離
- **`main.scala`**: `local` / Lambda とも `Left` は例外に変換（非0終了 / エラー応答）

## ⚠️ 挙動変更

従来は個別の API 失敗時に空リストで**継続**していたが、本対応では**最初のエラーで処理全体を中断**する（エラーを握りつぶさず可視化）。

## 後続

- #24: 本PRの Usecase 層（`flatMap`/`map`）を **for 内包表記へ移行**（構文変更のみ・本PRにスタック）

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み

refs #15
