### PR TITLE
refactor: Usecase 層を for 内包表記へ移行

### DIFF
--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -6,27 +6,27 @@ object Usecase {
   def getRepos: Either[AppError, (List[Models.Repo], List[String])] = {
     val userName = config.Config.instance.githubUsername
 
-    // 本人が所有するリポジトリ
-    RepoRepository.findByUsername(userName).flatMap { userRepos =>
+    for {
+      // 本人が所有するリポジトリ
+      userRepos <- RepoRepository.findByUsername(userName)
+
       // 本人が所属する org 一覧
-      OrganizationRepository.findByUsername(userName).flatMap { orgs =>
-        // 各 org について、本人がメンバーになっているチームだけを抽出する
-        // (org -> 所属チーム一覧 の対応)
-        traverse(orgs)(memberTeamsOf(_, userName)).flatMap { orgTeams =>
-          // 本人が所属するチームがアクセスできるリポジトリ
-          // (org/team を平坦化してから順に取得し、失敗時は以降を呼ばず短絡する)
-          traverse(
-            orgTeams.flatMap((org, teams) => teams.map(team => (org, team)))
-          ) { case (org, team) =>
-            RepoRepository.findByTeam(org.login, team.slug)
-          }.map { teamReposNested =>
-            val teamRepos = teamReposNested.flatten
-            // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
-            val teamSlugs = orgTeams.flatMap((_, teams) => teams).map(_.slug)
-            (userRepos ++ teamRepos, teamSlugs)
-          }
-        }
-      }
+      orgs <- OrganizationRepository.findByUsername(userName)
+
+      // 各 org について、本人がメンバーになっているチームだけを抽出する
+      // (org -> 所属チーム一覧 の対応)
+      orgTeams <- traverse(orgs)(memberTeamsOf(_, userName))
+
+      // 本人が所属するチームがアクセスできるリポジトリ
+      // (org/team を平坦化してから順に取得し、失敗時は以降を呼ばず短絡する)
+      teamReposNested <- traverse(
+        orgTeams.flatMap((org, teams) => teams.map(team => (org, team)))
+      ) { case (org, team) => RepoRepository.findByTeam(org.login, team.slug) }
+    } yield {
+      val teamRepos = teamReposNested.flatten
+      // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
+      val teamSlugs = orgTeams.flatMap((_, teams) => teams).map(_.slug)
+      (userRepos ++ teamRepos, teamSlugs)
     }
   }
 
@@ -35,15 +35,14 @@ object Usecase {
       org: Models.Organization,
       userName: String
   ): Either[AppError, (Models.Organization, List[Models.Team])] =
-    TeamRepository.findByOrganization(org.login).flatMap { teams =>
-      traverse(teams) { team =>
+    for {
+      teams <- TeamRepository.findByOrganization(org.login)
+      memberships <- traverse(teams) { team =>
         UserRepository
           .findByTeam(org.login, team.slug)
           .map(members => (team, members.exists(_.login == userName)))
-      }.map(memberships =>
-        (org, memberships.collect { case (team, true) => team })
-      )
-    }
+      }
+    } yield (org, memberships.collect { case (team, true) => team })
 
   def getAssignPulls: Either[
     AppError,
@@ -51,31 +50,33 @@ object Usecase {
   ] = {
     val userName = config.Config.instance.githubUsername
 
-    getRepos.flatMap { case (repos, teamSlugs) =>
+    for {
+      reposAndSlugs <- getRepos
+      (repos, teamSlugs) = reposAndSlugs
+
       // 対象リポジトリすべての open PR を集約する
       // repo.owner は Option のため owner 不明のリポジトリは対象から除外し、
       // (owner, repo) を順に取得して失敗時は以降を呼ばず短絡する
-      traverse(
+      pullsNested <- traverse(
         repos.flatMap(repo => repo.owner.toList.map(owner => (owner, repo)))
       ) { case (owner, repo) =>
         PullRepository.findByFullName(owner.login, repo.name)
-      }.map { pullsNested =>
-        val allPulls = pullsNested.flatten
-
-        // 本人が assignee に指定されている PR
-        val assignPulls =
-          allPulls.filter(_.assignees.exists(_.login == userName))
-        // 本人が個人としてレビュアー指名されている PR
-        val reviewerPulls =
-          allPulls.filter(_.requested_reviewers.exists(_.login == userName))
-        // 本人の所属チームがレビュアー指名されている PR
-        val teamReviewerPulls =
-          allPulls.filter(
-            _.requested_teams.exists(team => teamSlugs.contains(team.slug))
-          )
-
-        (assignPulls, reviewerPulls, teamReviewerPulls)
       }
+    } yield {
+      val allPulls = pullsNested.flatten
+
+      // 本人が assignee に指定されている PR
+      val assignPulls = allPulls.filter(_.assignees.exists(_.login == userName))
+      // 本人が個人としてレビュアー指名されている PR
+      val reviewerPulls =
+        allPulls.filter(_.requested_reviewers.exists(_.login == userName))
+      // 本人の所属チームがレビュアー指名されている PR
+      val teamReviewerPulls =
+        allPulls.filter(
+          _.requested_teams.exists(team => teamSlugs.contains(team.slug))
+        )
+
+      (assignPulls, reviewerPulls, teamReviewerPulls)
     }
   }
 }

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -4,19 +4,19 @@ import errors.AppError
 
 object Usecase {
   def check: Either[AppError, Unit] =
-    holiday.CheckHolidayRepository.get.flatMap { isHoliday =>
-      github.Usecase.getAssignPulls.flatMap {
-        case (assignPulls, reviewerPulls, teamReviewerPulls) =>
-          slack.PostRepository.sendAttachments(
-            buildAttachments(
-              isHoliday,
-              assignPulls,
-              reviewerPulls,
-              teamReviewerPulls
-            )
-          )
-      }
-    }
+    for {
+      isHoliday <- holiday.CheckHolidayRepository.get
+      pulls <- github.Usecase.getAssignPulls
+      (assignPulls, reviewerPulls, teamReviewerPulls) = pulls
+      _ <- slack.PostRepository.sendAttachments(
+        buildAttachments(
+          isHoliday,
+          assignPulls,
+          reviewerPulls,
+          teamReviewerPulls
+        )
+      )
+    } yield ()
 
   // 通知メッセージ(Slack Attachment)を組み立てる純粋ロジック
   private def buildAttachments(


### PR DESCRIPTION
## 概要

#23 で `flatMap`/`map` で記述した Either の合成を **for 内包表記へ移行**する。**ロジック・挙動の変更はなく、可読性向上のための構文変更のみ**。

> [!NOTE]
> このPRは #23 の上にスタックしています。base を `refactor/phase4-either`（#23）にしているため、**#23 を先にマージ**すると自動的に master へ retarget されます。

## 変更内容（2ファイルのみ）

- **`github/Usecase.scala`**: `getRepos` / `memberTeamsOf` / `getAssignPulls` を `flatMap`/`map` → for 内包表記
- **`notify/Usecase.scala`**: `check` を `flatMap`/`map` → for 内包表記

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み

refs #15
