### PR TITLE
refactor: フェーズ5 ランタイムループの tailrec 化と main の dead code 除去

### DIFF
--- a/src/main.scala
+++ b/src/main.scala
@@ -1,11 +1,9 @@
-import serverless.Lambda
-import notify.Usecase
 import errors.AppError
 
 @main def main = config.Config.instance.env match {
   case "local" =>
     // Left は例外として送出し非0終了させる(ローカル/CI で失敗を検知できるように)
-    handler("1970-01-01T00:00:00Z") match {
+    handler() match {
       case Right(_)  => ()
       case Left(err) => throw err.toException
     }
@@ -13,9 +11,10 @@ import errors.AppError
     serverless.Lambda
       .Handler[serverless.Lambda.CloudWatchScheduledEventRequest](
         "handler",
-        (event) => {
+        // イベント内容は使用しないため受け取らない
+        _ => {
           // Usecase の Left は例外に変換し、Lambda ランタイムのエラー応答に委ねる
-          handler(event.time) match {
+          handler() match {
             case Right(_)  => serverless.Lambda.Response(200, "ok")
             case Left(err) => throw err.toException
           }
@@ -23,4 +22,4 @@ import errors.AppError
       )
 }
 
-def handler(time: String): Either[AppError, Unit] = notify.Usecase.check
+def handler(): Either[AppError, Unit] = notify.Usecase.check

--- a/src/runtime/Lambda.scala
+++ b/src/runtime/Lambda.scala
@@ -2,6 +2,7 @@ package serverless
 
 import sttp.client4.quick._
 import upickle.default._
+import scala.annotation.tailrec
 
 object Lambda {
   case class CloudWatchScheduledEventRequest(
@@ -20,7 +21,11 @@ object Lambda {
 
     this
   }
-  private def handler[A: Reader](callback: A => Response): Lambda.type = {
+  // Lambda カスタムランタイムのイベントループ。
+  // /next で次の呼び出しを取得 → callback 実行 → /response か /error を通知、を繰り返す。
+  // 末尾再帰(@tailrec)とし、長時間稼働(ウォーム)でもスタックが伸びないことを保証する。
+  @tailrec
+  private def handler[A: Reader](callback: A => Response): Nothing = {
     val response = quickRequest
       .get(
         uri"http://${sys.env("AWS_LAMBDA_RUNTIME_API")}/2018-06-01/runtime/invocation/next"
@@ -58,6 +63,5 @@ object Lambda {
     }
 
     handler[A](callback)
-    this
   }
 }


### PR DESCRIPTION
## 概要

#15 のフェーズ5（ランタイム・エントリポイントの整理）。

## 変更内容

### `runtime/Lambda.scala` — イベントループの末尾再帰化
カスタムランタイムのイベントループ `handler` を `@tailrec` 化。

従来は自己呼び出し `handler[A](callback)` の**後に** `this` を返しており、再帰呼び出しが末尾位置になかった。このため呼び出しごとにスタックフレームが積まれ、**長時間稼働（ウォーム）した Lambda でスタックオーバーフローし得る**潜在バグがあった。戻り値型を `Nothing`（無限ループで正常 return しない）にして末尾再帰に修正し、スタックが伸びないことを保証する。

### `main.scala` — dead code 除去
- `handler(time: String)` の `time` 引数は `notify.Usecase.check` に渡されず破棄されていた（dead code）。引数を削除し `handler()` に
- あわせて未使用 import（`serverless.Lambda` / `notify.Usecase`、いずれも完全修飾で参照しており不要）を除去

## 挙動

- Lambda ループの動作は従来どおり（無限ループでの招待処理）。スタック安全性のみ改善
- `time` は元々未使用のため挙動に影響なし

## 確認

- `scala-cli compile .` でコンパイル成功（`@tailrec` も受理）
- `scalafmt` 適用済み

refs #15
