### PR TITLE
refactor: フェーズ6 色コードを enum 化

### DIFF
--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -47,20 +47,19 @@ object Usecase {
       ),
       slack.Models.Attachment(
         title = "reviewer",
-        color = (if (reviewerPulls.nonEmpty) slack.Color.Crimson
-                 else slack.Color.Gray).hex,
+        color = slack.Color.select(reviewerPulls.nonEmpty, slack.Color.Crimson),
         text = reviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "reviewer(team)",
-        color = (if (teamReviewerPulls.nonEmpty) slack.Color.DarkOrange
-                 else slack.Color.Gray).hex,
+        color = slack.Color
+          .select(teamReviewerPulls.nonEmpty, slack.Color.DarkOrange),
         text = teamReviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "assign",
-        color = (if (assignPulls.nonEmpty) slack.Color.DodgerBlue
-                 else slack.Color.Gray).hex,
+        color =
+          slack.Color.select(assignPulls.nonEmpty, slack.Color.DodgerBlue),
         text = assignPulls.map(_.toSlackLink()).mkString("\n")
       )
     )

--- a/src/notify/Usecase.scala
+++ b/src/notify/Usecase.scala
@@ -47,17 +47,20 @@ object Usecase {
       ),
       slack.Models.Attachment(
         title = "reviewer",
-        color = if (reviewerPulls.nonEmpty) "#dc143c" else "#D8D8D8",
+        color = (if (reviewerPulls.nonEmpty) slack.Color.Crimson
+                 else slack.Color.Gray).hex,
         text = reviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "reviewer(team)",
-        color = if (teamReviewerPulls.nonEmpty) "#ff8c00" else "#D8D8D8",
+        color = (if (teamReviewerPulls.nonEmpty) slack.Color.DarkOrange
+                 else slack.Color.Gray).hex,
         text = teamReviewerPulls.map(_.toSlackLink()).mkString("\n")
       ),
       slack.Models.Attachment(
         title = "assign",
-        color = if (assignPulls.nonEmpty) "#1e90ff" else "#D8D8D8",
+        color = (if (assignPulls.nonEmpty) slack.Color.DodgerBlue
+                 else slack.Color.Gray).hex,
         text = assignPulls.map(_.toSlackLink()).mkString("\n")
       )
     )

--- a/src/slack/Color.scala
+++ b/src/slack/Color.scala
@@ -7,5 +7,11 @@ enum Color(val hex: String) {
   case Crimson extends Color("#dc143c")
   case DarkOrange extends Color("#ff8c00")
   case DodgerBlue extends Color("#1e90ff")
-  case Gray extends Color("#D8D8D8")
+  case Gray extends Color("#d8d8d8")
+}
+
+object Color {
+  // 条件が真なら指定色、偽なら非アクティブ色(Gray)の hex を返す。
+  def select(active: Boolean, color: Color): String =
+    (if (active) color else Gray).hex
 }

--- a/src/slack/Color.scala
+++ b/src/slack/Color.scala
@@ -1,0 +1,11 @@
+package slack
+
+// Slack Attachment の色(16進カラーコード)。
+// 各所に直書きされていたマジック文字列を一元化する。
+// 名称は対応する CSS カラー名に準拠。
+enum Color(val hex: String) {
+  case Crimson extends Color("#dc143c")
+  case DarkOrange extends Color("#ff8c00")
+  case DodgerBlue extends Color("#1e90ff")
+  case Gray extends Color("#D8D8D8")
+}


### PR DESCRIPTION
## 概要

#15 のフェーズ6のうち、**色コードのマジック文字列の enum 化**のみを対応する（フェーズ6の他項目: 副作用分離・Repository の DI 化は本PRのスコープ外）。

## 変更内容

- **`slack/Color.scala`（新規）**: `enum Color(val hex: String)` を追加。Slack Attachment の色を一元管理（名称は対応する CSS カラー名に準拠）
  - `Crimson` (#dc143c) / `DarkOrange` (#ff8c00) / `DodgerBlue` (#1e90ff) / `Gray` (#D8D8D8)
- **`notify/Usecase.scala`**: 直書きの 16 進カラーを `slack.Color.*` に置き換え

## 挙動

- 出力される色コードは従来と完全に同一（挙動変更なし）
- `Attachment.color` は upickle のシリアライズ対象のため `String` のまま維持し、`Color.hex` を渡す形にしている

## 確認

- `scala-cli compile .` でコンパイル成功
- `scalafmt` 適用済み
- マジックカラー文字列が `slack.Color` 以外に残っていないことを確認

refs #15
