### PR TITLE
fix: リポジトリ重複を排除し Slack 通知の PR 重複表示を防ぐ

### DIFF
--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -26,7 +26,11 @@ object Usecase {
       val teamRepos = teamReposNested.flatten
       // 本人が所属するチームの slug 一覧。後段でチーム宛レビュー依頼の判定に使う
       val teamSlugs = orgTeams.flatMap((_, teams) => teams).map(_.slug)
-      (userRepos ++ teamRepos, teamSlugs)
+      // userRepos と teamRepos、または複数チーム間で同一リポジトリが重複しうるため
+      // full_name をキーに一意化する。これにより PullRepository.findByFullName の
+      // 無駄な呼び出しと Slack 通知での PR 重複表示を防ぐ
+      val repos = (userRepos ++ teamRepos).distinctBy(_.full_name)
+      (repos, teamSlugs)
     }
   }
 


### PR DESCRIPTION
## 概要

Closes #20

`github.Usecase.getRepos` が `userRepos ++ teamRepos` を単純結合していたため、リポジトリ一覧に重複が含まれうる問題を解消する。重複により以下が発生していた。

- 同一リポジトリに対して `PullRepository.findByFullName` が複数回呼ばれ、無駄な API リクエストが発生
- `allPulls` に同じ PR が重複して含まれ、**Slack 通知に同じ PR が複数表示される**

### 発生ケース
1. 本人所有リポジトリ（`userRepos`）と所属チームのリポジトリ（`teamRepos`）が重複
2. 複数の所属チームが同じリポジトリにアクセス権を持つ（`teamRepos` 内で重複）

## 変更内容

`getRepos` の返り値生成時に `full_name` をキーとして `distinctBy` で一意化。

```scala
val repos = (userRepos ++ teamRepos).distinctBy(_.full_name)
```

`.distinct`（構造的等価）ではなく `full_name` キーにすることで、`owner` 等の付随フィールドに差異があっても確実に同一リポジトリを一意化できる。

## 確認

- `scala-cli compile .` でコンパイル成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)