### PR TITLE
fix: repos / team repos / pulls 取得をページネーション対応する (#30)

### DIFF
--- a/src/github/Repository.scala
+++ b/src/github/Repository.scala
@@ -71,7 +71,7 @@ private def getListAll[T: Reader](
 
 object RepoRepository {
   def findByUsername(username: String): Either[AppError, List[Models.Repo]] =
-    getList[Models.Repo](
+    getListAll[Models.Repo](
       uri"${GITHUB_API_URL}/users/${username}/repos",
       s"user(${username}) repos data"
     )
@@ -80,7 +80,7 @@ object RepoRepository {
       login: String,
       slug: String
   ): Either[AppError, List[Models.Repo]] =
-    getList[Models.Repo](
+    getListAll[Models.Repo](
       uri"${GITHUB_API_URL}/orgs/${login}/teams/${slug}/repos",
       s"team(${login}, ${slug}) repos data"
     )
@@ -125,7 +125,7 @@ object PullRepository {
       owner: String,
       name: String
   ): Either[AppError, List[Models.Pull]] =
-    getList[Models.Pull](
+    getListAll[Models.Pull](
       uri"${GITHUB_API_URL}/repos/${owner}/${name}/pulls",
       s"target(${owner}, ${name}) pulls data"
     )


### PR DESCRIPTION
## 概要

issue #30 の対応。`getList` を使う以下の取得は GitHub API のページネーション（per_page 既定 30、最大 100）に未対応で1ページ目しか取得しておらず、対象が31件以上あると取りこぼしていた。

PR #29 で `/user/teams` 向けに追加した `getListAll`（per_page=100 で取得件数が100未満になるまで全ページを辿る共通処理）を適用する。

## 変更点

`src/github/Repository.scala` の以下を `getList` → `getListAll` に変更:

- `RepoRepository.findByUsername` … `GET /users/{username}/repos`
- `RepoRepository.findByTeam` … `GET /orgs/{login}/teams/{slug}/repos`
- `PullRepository.findByFullName` … `GET /repos/{owner}/{name}/pulls`

## 動作確認

- `scala-cli compile .` 成功

closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)