### PR TITLE
perf: PR/チームリポジトリ取得を並列化する (#25)

### DIFF
--- a/project.scala
+++ b/project.scala
@@ -5,3 +5,6 @@
 //> using platform native
 //> using toolkit default
 //> using dep "com.lihaoyi::upickle:4.4.2"
+// HTTP 取得の並列化(errors.parTraverse)でスレッドを使うため明示的に有効化する。
+// Scala Native 0.5 では既定で有効だが、依存しないよう明示する。
+//> using nativeMultithreading true

--- a/src/errors/Parallel.scala
+++ b/src/errors/Parallel.scala
@@ -1,0 +1,40 @@
+package errors
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import java.util.concurrent.Executors
+
+// traverse の並列版。List[A] の各要素に f を並列適用し Either[E, List[B]] にまとめる。
+//
+// 逐次の traverse と異なり「最初の失敗で以降を呼ばない」短絡はできない(全要素を
+// 同時に走らせるため)。代わりに全要素を実行したうえで、Left があれば元の順序で
+// 最初の Left を返し、無ければ Right(順序保持) を返す。エラー集約の観点では
+// 逐次版と同じ「最初のエラーを返す」挙動を保つ。
+//
+// GitHub API のレートリミットに配慮し、同時実行数は maxConcurrency に制限する
+// (固定スレッドプールで上限を設け、超過分はキューで待たせる)。
+//
+// 実行環境は Scala Native 0.5 のマルチスレッド(project.scala で有効化)。
+// HTTP backend(sttp curl)は送信ごとに curl easy handle を生成・破棄するため、
+// スレッド間で可変ハンドルを共有しない。
+val DEFAULT_MAX_CONCURRENCY = 8
+
+def parTraverse[E, A, B](
+    xs: List[A],
+    maxConcurrency: Int = DEFAULT_MAX_CONCURRENCY
+)(f: A => Either[E, B]): Either[E, List[B]] =
+  if (xs.isEmpty) Right(Nil)
+  else {
+    val pool = Executors.newFixedThreadPool(math.min(maxConcurrency, xs.size))
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(pool)
+    try {
+      val futures = xs.map(x => Future(f(x)))
+      val results = Await.result(Future.sequence(futures), Duration.Inf)
+      results.collectFirst { case Left(e) => e } match {
+        case Some(e) => Left(e)
+        case None    => Right(results.collect { case Right(b) => b })
+      }
+    } finally {
+      pool.shutdown()
+    }
+  }

--- a/src/github/Usecase.scala
+++ b/src/github/Usecase.scala
@@ -1,6 +1,6 @@
 package github
 
-import errors.{AppError, traverse}
+import errors.{AppError, traverse, parTraverse}
 
 object Usecase {
   def getRepos: Either[AppError, (List[Models.Repo], List[String])] = {
@@ -45,8 +45,9 @@ object Usecase {
         .distinctBy { case (org, team) => (org.login, team.slug) }
 
       // 本人が所属するチームがアクセスできるリポジトリ
-      // (org/team を順に取得し、失敗時は以降を呼ばず短絡する)
-      teamReposNested <- traverse(expanded) { case (org, team) =>
+      // チーム数に比例して遅くなるため並列取得する(失敗時は元の順序で最初の
+      // エラーを返す)
+      teamReposNested <- parTraverse(expanded) { case (org, team) =>
         RepoRepository.findByTeam(org.login, team.slug)
       }
     } yield {
@@ -94,9 +95,10 @@ object Usecase {
       (repos, teamSlugs) = reposAndSlugs
 
       // 対象リポジトリすべての open PR を集約する
-      // repo.owner は Option のため owner 不明のリポジトリは対象から除外し、
-      // (owner, repo) を順に取得して失敗時は以降を呼ばず短絡する
-      pullsNested <- traverse(
+      // repo.owner は Option のため owner 不明のリポジトリは対象から除外する。
+      // リポジトリ数に比例して遅くなるため並列取得する(失敗時は元の順序で
+      // 最初のエラーを返す。逐次の短絡とはエラー集約方針を揃えてある)
+      pullsNested <- parTraverse(
         repos.flatMap(repo => repo.owner.toList.map(owner => (owner, repo)))
       ) { case (owner, repo) =>
         PullRepository.findByFullName(owner.login, repo.name)


### PR DESCRIPTION
## 概要

issue #25 の対応。`getAssignPulls` の PR 取得と `getRepos` のチームリポジトリ取得が**逐次実行**のため、リポジトリ数・チーム数に比例して Lambda 実行時間が伸び、レートリミット超過やタイムアウトのリスクがあった。固定スレッドプールで同時実行数を制限する `traverse` の並列版 `errors.parTraverse` を導入して並列化する。

## 変更点

- `src/errors/Parallel.scala` に `parTraverse` を追加（`maxConcurrency` 既定 8）
  - 逐次版の「最初の失敗で以降を呼ばない」短絡は並列実行のため保てない。代わりに全要素を実行し、**元の順序で最初の `Left`** を返す（エラー集約方針は逐次版と同じ「最初のエラーを返す」を維持。挙動変更は #25 で許容済み）
  - GitHub API レートリミット配慮のため固定スレッドプールで同時実行数を制限（超過分はキュー待ち）
- `src/github/Usecase.scala` の PR 取得とチームリポジトリ取得を `traverse` → `parTraverse` に置き換え
- `project.scala` で `nativeMultithreading` を明示的に有効化（SN 0.5 は既定で有効だが依存しないよう明示）

## スレッド安全性

- sttp curl backend（`AbstractCurlBackend.send`）は**送信ごとに curl easy handle を生成・破棄**するため、スレッド間で可変ハンドルを共有しない
- libcurl の `curl_global_init`（初回 `curl_easy_init` で発火、非スレッドセーフ）は、`getRepos` の逐次フェーズ（認証ユーザー/リポジトリ/チーム取得）が並列フェーズより前に走るため warm-up 済みになり、初回 init の競合を回避

## 検証

- ✅ ローカルで Scala Native パッケージビルド成功（`multithreadingEnabled=true`、`pthread`/`curl` とリンク）
- ✅ 並列 curl の実行時スモークテスト（warm-up 後に 8 スレッドで 12 並列 HTTP）→ 全件 200・クラッシュ無し・8 スレッドで実並列を確認
- ⚠️ **本番同等の `provided.al2023`（amazonlinux の libcurl/glibc）での最終確認は未実施**。ローカルは macOS の libcurl のため、このPRの dev デプロイ後に dev を実行して動作確認してからマージしてください。

closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)